### PR TITLE
Move all signature checks into SignatureValidator...

### DIFF
--- a/src/SignatureValidator/DefaultSignatureValidator.php
+++ b/src/SignatureValidator/DefaultSignatureValidator.php
@@ -3,6 +3,7 @@
 namespace Spatie\WebhookClient\SignatureValidator;
 
 use Illuminate\Http\Request;
+use Spatie\WebhookClient\Events\InvalidSignatureEvent;
 use Spatie\WebhookClient\WebhookConfig;
 use Spatie\WebhookClient\Exceptions\WebhookFailed;
 
@@ -11,6 +12,8 @@ class DefaultSignatureValidator implements SignatureValidator
     public function isValid(Request $request, WebhookConfig $config): bool
     {
         $signature = $request->header($config->signatureHeaderName);
+
+        $this->checkSignatureExists($signature, $request, $config);
 
         $signingSecret = $config->signingSecret;
 
@@ -21,5 +24,13 @@ class DefaultSignatureValidator implements SignatureValidator
         $computedSignature = hash_hmac('sha256', $request->getContent(), $signingSecret);
 
         return hash_equals($signature, $computedSignature);
+    }
+
+    protected function checkSignatureExists($signature, Request $request, WebhookConfig $config)
+    {
+        if (! $signature) {
+            event(new InvalidSignatureEvent($request, $signature));
+            throw WebhookFailed::missingSignature($config->signatureHeaderName);
+        }
     }
 }

--- a/tests/WebhookConfigTest.php
+++ b/tests/WebhookConfigTest.php
@@ -50,7 +50,7 @@ class WebhookConfigTest extends TestCase
     }
 
     /** @test */
-    public function it_validates_the_process_webhook_ojb()
+    public function it_validates_the_process_webhook_jpb()
     {
         $config = $this->getValidConfig();
         $config['process_webhook_job'] = 'invalid-process-webhook-job';

--- a/tests/WebhookConfigTest.php
+++ b/tests/WebhookConfigTest.php
@@ -50,7 +50,7 @@ class WebhookConfigTest extends TestCase
     }
 
     /** @test */
-    public function it_validates_the_process_webhook_jpb()
+    public function it_validates_the_process_webhook_job()
     {
         $config = $this->getValidConfig();
         $config['process_webhook_job'] = 'invalid-process-webhook-job';


### PR DESCRIPTION
This enables user to skip signature validation completely via custom validator. Simply return true from isValid method and it's skipped.

Moved signature exist check into protected method to give option of extending default validator and reusing functionality.

I didnt really see it necessary to add any new tests this time around. All tests are still passing and if Im honest this was my assumption on behaviour anyway. So I think we're good :)