### PR TITLE
Remove handle abstract method from ProcessWebhookJob

### DIFF
--- a/src/ProcessWebhookJob.php
+++ b/src/ProcessWebhookJob.php
@@ -20,6 +20,4 @@ abstract class ProcessWebhookJob implements ShouldQueue
     {
         $this->webhookCall = $webhookCall;
     }
-
-    abstract public function handle();
 }


### PR DESCRIPTION
Having an abstract `handle` method stops dependencies from
being type hinted. By removing it users will have to implement the
method by themselves but hopefully most users will be familiar with
that.

Fixes #10 