### PR TITLE
Use bigIncrements for primary key

### DIFF
--- a/database/migrations/create_webhook_calls_table.php.stub
+++ b/database/migrations/create_webhook_calls_table.php.stub
@@ -8,7 +8,7 @@ class CreateWebhookCallsTable extends Migration
     public function up()
     {
         Schema::create('webhook_calls', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
 
             $table->string('name');
             $table->text('payload')->nullable();


### PR DESCRIPTION
Laravel has switched to use `bigIncrements` in migrations.