### PR TITLE
Allow for overriding the webhook response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-webhook-client` will be documented in this file
 
+## 2.4.0 - 2019-12-08
+
+- drop support for PHP 7.3 and below
+
 ## 2.3.0 - 2019-10-30
 
 - add `WebhookConfigRepository` to make it easier to programmatically add config 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Quality Score](https://img.shields.io/scrutinizer/g/spatie/laravel-webhook-client.svg?style=flat-square)](https://scrutinizer-ci.com/g/spatie/laravel-webhook-client)
 [![Total Downloads](https://img.shields.io/packagist/dt/spatie/laravel-webhook-client.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-webhook-client)
 
-A webhook is a way for an app to provide information to another app about a specific event. The way the two apps communicate is with a simple HTTP request. 
+A webhook is a way for an app to provide information to another app about a specific event. The way the two apps communicate is with a simple HTTP request.
 
 This package allows you to receive webhooks in a Laravel app. It has support for [verifying signed calls](#verifying-the-signature-of-incoming-webhooks), [storing payloads and processing the payloads](#storing-and-processing-webhooks) in a queued job.
 
@@ -70,6 +70,12 @@ return [
             'webhook_model' => \Spatie\WebhookClient\Models\WebhookCall::class,
 
             /*
+             * The controller to use when handling the initial webhook response.  This will use
+             * the Spatie package default if not provided. This should return a valid Illuminate\Http\Response.
+             */
+            'webhook_response' => null,
+
+            /*
              * The class name of the job that will process the webhook request.
              *
              * This should be set to a class that extends \Spatie\WebhookClient\ProcessWebhookJob.
@@ -81,7 +87,7 @@ return [
 
 In the `signing_secret` key of the config file, you should add a valid webhook secret. This value should be provided by the app that will send you webhooks.
 
-This package will try to store and respond to the webhook as fast as possible. Processing the payload of the request is done via a queued job.  It's recommended to not use the `sync` driver but a real queue driver. You should specify the job that will handle processing webhook requests in the `process_webhook_job` of the config file. A valid job is any class that extends `Spatie\WebhookClient\ProcessWebhookJob` and has a `handle` method. 
+This package will try to store and respond to the webhook as fast as possible. Processing the payload of the request is done via a queued job.  It's recommended to not use the `sync` driver but a real queue driver. You should specify the job that will handle processing webhook requests in the `process_webhook_job` of the config file. A valid job is any class that extends `Spatie\WebhookClient\ProcessWebhookJob` and has a `handle` method.
 
 ### Preparing the database
 
@@ -116,13 +122,13 @@ protected $except = [
 
 ## Usage
 
-With the installation out of the way, let's take a look at how this package handles webhooks. First, it will verify if the signature of the request is valid. If it is not, we'll throw an exception and fire off the `InvalidSignatureEvent` event. Requests with invalid signatures will not be stored in the database. 
+With the installation out of the way, let's take a look at how this package handles webhooks. First, it will verify if the signature of the request is valid. If it is not, we'll throw an exception and fire off the `InvalidSignatureEvent` event. Requests with invalid signatures will not be stored in the database.
 
 Next, the request will be passed to a webhook profile. A webhook profile is a class that determines if a request should be stored and processed by your app. It allows you to filter out webhook requests that are of interest to your app. You can easily create [your own webhook profile](#determining-which-webhook-requests-should-be-stored-and-processed).
 
 If the webhook profile determines that request should be stored and processed, we'll first store it in the `webhook_calls` table. After that, we'll pass that newly created `WebhookCall` model to a queued job. Most webhook sending apps expect you to respond very quickly. Offloading the real processing work allows for speedy responses. You can specify which job should process the webhook in the `process_webhook_job` in the `webhook-client` config file. Should an exception be thrown while queueing the job, the package will store that exception in the `exception` attribute on the `WebhookCall` model.
 
-After the job has been dispatched, the controller will respond with a `200` status code. 
+After the job has been dispatched, the controller will respond with a `200` status code.
 
 ### Verifying the signature of incoming webhooks
 
@@ -136,7 +142,7 @@ If the `$computedSignature` does match the value, the request will be [passed to
 
 ### Creating your own signature validator
 
-A signature validator is any class that implements `Spatie\WebhookClient\SignatureValidator\SignatureValidator`. Here's what that interface looks like. 
+A signature validator is any class that implements `Spatie\WebhookClient\SignatureValidator\SignatureValidator`. Here's what that interface looks like.
 
 ```php
 use Illuminate\Http\Request;
@@ -148,7 +154,7 @@ interface SignatureValidator
 }
 ```
 
-`WebhookConfig` is a data transfer object that lets you easily pull up the config (containing the header name that contains the signature and the secret) for the webhook request. 
+`WebhookConfig` is a data transfer object that lets you easily pull up the config (containing the header name that contains the signature and the secret) for the webhook request.
 
 After creating your own `SignatureValidator` you must register it in the `signature_validator` in the `webhook-client` config file.
 
@@ -177,9 +183,9 @@ After creating your own `WebhookProfile` you must register it in the `webhook_pr
 
 ### Storing and processing webhooks
 
-After the signature is validated and the webhook profile has determined that the request should be processed, the package will store and process the request. 
+After the signature is validated and the webhook profile has determined that the request should be processed, the package will store and process the request.
 
-The request will first be stored in the `webhook_calls` table. This is done using the `WebhookCall` model. 
+The request will first be stored in the `webhook_calls` table. This is done using the `WebhookCall` model.
 
 Should you want to customize the table name or anything on the storage behavior, you can let the package use an alternative model. A webhook storing model can be specified in the `webhook_model`. Make sure you model extends `Spatie\WebhookClient\Models\WebhookCall`.
 
@@ -197,13 +203,13 @@ class ProcessWebhookJob extends SpatieProcessWebhookJob
     public function handle()
     {
         // $this->webhookCall // contains an instance of `WebhookCall`
-    
+
         // perform the work here
     }
 }
 ```
 
-You should specify the class name of your job in the `process_webhook_job` of the `webhook-client` config file. 
+You should specify the class name of your job in the `process_webhook_job` of the `webhook-client` config file.
 
 ### Handling incoming webhook request for multiple apps
 
@@ -298,7 +304,7 @@ We publish all received postcards [on our company website](https://spatie.be/en/
 
 Spatie is a web design agency based in Antwerp, Belgium. You'll find an overview of all our open source projects [on our website](https://spatie.be/opensource).
 
-Does your business depend on our contributions? Reach out and support us on [Patreon](https://www.patreon.com/spatie). 
+Does your business depend on our contributions? Reach out and support us on [Patreon](https://www.patreon.com/spatie).
 All pledges will be dedicated to allocating workforce on maintenance and new awesome stuff.
 
 ## License

--- a/config/webhook-client.php
+++ b/config/webhook-client.php
@@ -40,7 +40,7 @@ return [
 
             /*
              * The controller to use when handling the initial webhook response.  This will use
-             * the Spatie package default if not provided.
+             * the Spatie package default if not provided. This should return a valid Illuminate\Http\Response.
              */
             'webhook_response' => null,
 

--- a/src/WebhookConfig.php
+++ b/src/WebhookConfig.php
@@ -20,6 +20,8 @@ class WebhookConfig
 
     public string $webhookModel;
 
+    public string $webhookResponse;
+
     public ProcessWebhookJob $processWebhookJob;
 
     public function __construct(array $properties)
@@ -42,7 +44,9 @@ class WebhookConfig
 
         $this->webhookModel = $properties['webhook_model'];
 
-        $this->webhookResponse = $properties['webhook_response'] ? app($properties['webhook_response']) : '';
+        $this->webhookResponse = array_key_exists('webhook_response', $properties) && $properties['webhook_response']
+            ? $properties['webhook_response']
+            : '';
 
         if (! is_subclass_of($properties['process_webhook_job'], ProcessWebhookJob::class)) {
             throw InvalidConfig::invalidProcessWebhookJob($properties['process_webhook_job']);

--- a/src/WebhookController.php
+++ b/src/WebhookController.php
@@ -10,6 +10,10 @@ class WebhookController
     {
         (new WebhookProcessor($request, $config))->process();
 
+        if ($config->webhookResponse) {
+            return $config->webhookReponse->response($request);
+        }
+
         return response()->json(['message' => 'ok']);
     }
 }

--- a/src/WebhookController.php
+++ b/src/WebhookController.php
@@ -9,9 +9,10 @@ class WebhookController
     public function __invoke(Request $request, WebhookConfig $config)
     {
         (new WebhookProcessor($request, $config))->process();
+        if ($class = $config->webhookResponse) {
+            $handler = new $class;
 
-        if ($config->webhookResponse) {
-            return $config->webhookReponse->response($request);
+            return $handler->response($request);
         }
 
         return response()->json(['message' => 'ok']);


### PR DESCRIPTION
Currently the webhook early returns a ok 200 response no matter what with no way to modify that return.  This allows for a custom class to handle that return process such that other fields (eg: challenge answer for slack) can be injected in the early return.