### PR TITLE
Removed variable type causing error

### DIFF
--- a/src/ProcessWebhookJob.php
+++ b/src/ProcessWebhookJob.php
@@ -13,7 +13,7 @@ abstract class ProcessWebhookJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public WebhookCall $webhookCall;
+    public $webhookCall;
 
     public function __construct(WebhookCall $webhookCall)
     {


### PR DESCRIPTION
This is in relation to the issue found here https://github.com/spatie/laravel-stripe-webhooks/issues/57.  This commit was the fix 