### PR TITLE
Add support for web hooks that use GET requests

### DIFF
--- a/src/WebhookClientServiceProvider.php
+++ b/src/WebhookClientServiceProvider.php
@@ -25,7 +25,7 @@ class WebhookClientServiceProvider extends ServiceProvider
             ], 'migrations');
         }
 
-        Route::macro('webhooks', fn (string $url, string $name = 'default') => Route::post($url, '\Spatie\WebhookClient\WebhookController')->name("webhook-client-{$name}"));
+        Route::macro('webhooks', fn (string $url, string $name = 'default', string $method = 'post') => Route::{$method}($url, '\Spatie\WebhookClient\WebhookController')->name("webhook-client-{$name}"));
 
         $this->app->singleton(WebhookConfigRepository::class, function () {
             $configRepository = new WebhookConfigRepository();


### PR DESCRIPTION
We _unfortunately_ have to support a API that is sending us web hooks via a GET request and query string arguments. This change will allow us to override the Route method. For example

```
Route::webhooks('test-service', 'test-service-name', 'GET');
```