### PR TITLE
Support for validation GitHub's signature as default

### DIFF
--- a/src/SignatureValidator/DefaultSignatureValidator.php
+++ b/src/SignatureValidator/DefaultSignatureValidator.php
@@ -3,6 +3,7 @@
 namespace Spatie\WebhookClient\SignatureValidator;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use Spatie\WebhookClient\Exceptions\InvalidConfig;
 use Spatie\WebhookClient\WebhookConfig;
 
@@ -11,6 +12,10 @@ class DefaultSignatureValidator implements SignatureValidator
     public function isValid(Request $request, WebhookConfig $config): bool
     {
         $signature = $request->header($config->signatureHeaderName);
+
+        if (Str::startsWith($signature, $prefix = 'sha256=')) {
+            $signature = Str::after($signature, $prefix);
+        }
 
         if (! $signature) {
             return false;

--- a/tests/WebhookControllerTest.php
+++ b/tests/WebhookControllerTest.php
@@ -65,6 +65,19 @@ class WebhookControllerTest extends TestCase
     }
 
     /** @test */
+    public function it_can_process_github_webhook_request_as_default()
+    {
+        $this->withoutExceptionHandling();
+
+        $headers = $this->headers;
+        $headers['Signature'] = 'sha256=' . $headers['Signature'];
+
+        $this
+            ->postJson('incoming-webhooks', $this->payload, $headers)
+            ->assertSuccessful();
+    }
+
+    /** @test */
     public function a_request_with_an_invalid_payload_will_not_get_processed()
     {
         $headers = $this->headers;

--- a/tests/WebhookControllerTest.php
+++ b/tests/WebhookControllerTest.php
@@ -75,6 +75,17 @@ class WebhookControllerTest extends TestCase
         $this
             ->postJson('incoming-webhooks', $this->payload, $headers)
             ->assertSuccessful();
+
+        $this->assertCount(1, WebhookCall::get());
+        $webhookCall = WebhookCall::first();
+        $this->assertEquals('default', $webhookCall->name);
+        $this->assertEquals(['a' => 1], $webhookCall->payload);
+
+        Queue::assertPushed(ProcessWebhookJobTestClass::class, function (ProcessWebhookJobTestClass $job) {
+            $this->assertEquals(1, $job->webhookCall->id);
+
+            return true;
+        });
     }
 
     /** @test */


### PR DESCRIPTION
Github's signature starts with `sha256=` and we usually have to write custom Validator for it. And because GitHub is quite popular so I think it could be support as default is good.