### PR TITLE
Return the Route object for method chaining

### DIFF
--- a/src/WebhookClientServiceProvider.php
+++ b/src/WebhookClientServiceProvider.php
@@ -22,7 +22,7 @@ class WebhookClientServiceProvider extends PackageServiceProvider
     public function packageBooted()
     {
         Route::macro('webhooks', function (string $url, string $name = 'default') {
-            Route::post($url, WebhookController::class)->name("webhook-client-{$name}");
+            return Route::post($url, WebhookController::class)->name("webhook-client-{$name}");
         });
 
         $this->app->singleton(WebhookConfigRepository::class, function () {


### PR DESCRIPTION
In Version 2 the macro returned the Route object, for example you could add a middleware:
```php
Route::webhooks('example')->middleware('auth.webhook');
```
This breaks with the update to v3. Simply returning the Object again solves this issue.