### PR TITLE
Queue Name Configuration

### DIFF
--- a/config/webhook-client.php
+++ b/config/webhook-client.php
@@ -59,6 +59,11 @@ return [
              * This should be set to a class that extends \Spatie\WebhookClient\ProcessWebhookJob.
              */
             'process_webhook_job' => '',
+
+            /*
+             * The name of the queue on which you want to dispatch your job
+             */
+            'queue_name' => 'default',
         ],
     ],
 ];

--- a/src/WebhookConfig.php
+++ b/src/WebhookConfig.php
@@ -29,6 +29,8 @@ class WebhookConfig
 
     public string $processWebhookJobClass;
 
+    public string $queueName;
+
     public function __construct(array $properties)
     {
         $this->name = $properties['name'];
@@ -62,5 +64,7 @@ class WebhookConfig
         }
 
         $this->processWebhookJobClass = $properties['process_webhook_job'];
+
+        $this->queueName = $properties['queue_name'];
     }
 }

--- a/src/WebhookProcessor.php
+++ b/src/WebhookProcessor.php
@@ -55,7 +55,7 @@ class WebhookProcessor
 
             $webhookCall->clearException();
 
-            dispatch($job);
+            dispatch($job)->onQueue($this->config->queueName);
         } catch (Exception $exception) {
             $webhookCall->saveException($exception);
 


### PR DESCRIPTION
I think it will be really helpful if user can configure the name of queue on which the jobs will be dispatched. Write now, there is no such configuration available & all jobs are getting dispatched on "default" queue. I hope this change will bring some more dynamics to the repos. 