### PR TITLE
[3.x] Don't serialize models by default

### DIFF
--- a/src/Jobs/ProcessWebhookJob.php
+++ b/src/Jobs/ProcessWebhookJob.php
@@ -6,7 +6,6 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
 use Spatie\WebhookClient\Models\WebhookCall;
 
 abstract class ProcessWebhookJob implements ShouldQueue

--- a/src/Jobs/ProcessWebhookJob.php
+++ b/src/Jobs/ProcessWebhookJob.php
@@ -14,7 +14,6 @@ abstract class ProcessWebhookJob implements ShouldQueue
     use Dispatchable;
     use InteractsWithQueue;
     use Queueable;
-    use SerializesModels;
 
     public function __construct(
         public WebhookCall $webhookCall


### PR DESCRIPTION
Storing the webhook payload in the database works well by default for small apps, but this can add a lot of friction for larger apps. For larger apps, usually, infrastructure is set in place to monitor the webhooks and all the traffic, so the database is redundant. Also, even if the webhook client stores the model and then deletes it to avoid data clogging, it's still an issue because it adds two transactions (insert/delete).

By default, the processing job is serializing the models. With this PR, removing the trait to serialize the models will make the models not get pulled from the database via serializing/deserializing and process the job instead of failing with `404 Not Found` because of a non-existing model.

This however requires a custom `WebhookCall` that changes the `storeWebhook`, `saveException` and `clearException` with something like below.

Related issue: #76 

```php

namespace App\WebhookCalls;

use Exception;
use Illuminate\Http\Request;
use Spatie\WebhookClient\Models\WebhookCall;
use Spatie\WebhookClient\WebhookConfig;

class OperatorV1WebhookCall extends WebhookCall
{
    public static function storeWebhook(WebhookConfig $config, Request $request): WebhookCall
    {
        return new Self([
            'name' => $config->name,
            'url' => $request->fullUrl(),
            'headers' => self::headersToStore($config, $request),
            'payload' => $request->input(),
        ]);
    }

    public function saveException(Exception $exception): self
    {
        $this->fill([
            'exception' => [
                'code' => $exception->getCode(),
                'message' => $exception->getMessage(),
                'trace' => $exception->getTraceAsString(),
            ],
        ]);

        return $this;
    }

    public function clearException(): self
    {
        return $this->fill(['exception' => null]);
    }
}
```