### PR TITLE
Fix typo

### DIFF
--- a/config/webhook-client.php
+++ b/config/webhook-client.php
@@ -44,7 +44,7 @@ return [
             'webhook_model' => \Spatie\WebhookClient\Models\WebhookCall::class,
 
             /*
-             * In this array, you can pass the headers that should be store on
+             * In this array, you can pass the headers that should be stored on
              * the webhook call model when a webhook comes in.
              *
              * To store all headers, set this value to `*`.


### PR DESCRIPTION
This PR fixes a typo.

- `...you can pass the headers that should be store..."
- `...you can pass the headers that should be store**d**..."