### PR TITLE
Align migration information with Stripe package

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,10 +1,50 @@
 ## From v2 to v3
 
-- add a migration to add `url` and `headers` columns to the `webhook_calls` table.
-  
+#### Create Migration
+```bash
+php artisan make:migration add_columns_to_webhook_calls
+```
+
+###  Here's an example how your migration should look.
 ```php
-$table->string('url')->nullable();
-$table->json('headers')->nullable();
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddColumnsToWebhookCalls extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('webhook_calls', function (Blueprint $table) {
+            $table->string('url')->nullable();
+            $table->json('headers')->nullable();
+            $table->json('payload')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('webhook_calls', function (Blueprint $table) {
+            $table->dropColumn('url');
+            $table->dropColumn('headers');
+            $table->text('payload')->change();
+        });
+    }
+}
 ```
 
 - add a key `store_headers` to each entry in `configs` of the `webhook-client` config file. See the default config file for an example.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -9,8 +9,6 @@ php artisan make:migration add_columns_to_webhook_calls
 ```php
 <?php
 
-declare(strict_types=1);
-
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;


### PR DESCRIPTION
We use both of your webhook packages, this and the Stripe one. On the stripe package's [upgrade guide](https://github.com/spatie/laravel-stripe-webhooks/blob/main/UPGRADING.md) it mentions changing the `payload` from `text` to `json`. This PR aligns both packages to use the same migration information.