### PR TITLE
set default config value to 30 days

### DIFF
--- a/config/webhook-client.php
+++ b/config/webhook-client.php
@@ -67,5 +67,5 @@ return [
      *
      * 7 deletes all records after 1 week. Set to null if no models should be deleted.
      */
-    'delete_after_days' => null,
+    'delete_after_days' => 30,
 ];


### PR DESCRIPTION
Hi @freekmurze 

The prunable feature was added in PR https://github.com/spatie/laravel-webhook-client/pull/166

The `delete_after_days` value is set to `null` by default, and end user is required to set this value in their project.
This PR sets the default value to 30 days. This will reduce the steps to setup the ModelPrune command.

Have a default value for `delete_after_days`  is harmless, because it is not effective/unused unless developer configure the schedule their-self.

Thanks.