### PR TITLE
Fix missing "down" function in webhook_calls migration (Issue #185)

### DIFF
--- a/database/migrations/create_webhook_calls_table.php.stub
+++ b/database/migrations/create_webhook_calls_table.php.stub
@@ -20,4 +20,9 @@ return new class extends Migration
             $table->timestamps();
         });
     }
+    
+    public function down()
+    {
+        Schema::dropIfExists('webhook_calls');
+    }
 };


### PR DESCRIPTION
**Description:**

This pull request addresses Issue #185 by adding the missing `down` function to the `webhook_calls` migration. This ensures proper rollback of the migration, preventing conflicts during subsequent migrations.

**Changes:**

- Added `down` function to the `webhook_calls` migration, which drops the `webhook_calls` table using the `Schema::dropIfExists` method.

**Testing:**

1. Run `php artisan migrate` to apply the package's migrations.
2. Run `php artisan migrate:rollback` to rollback the migrations.
3. Confirm that the `webhook_calls` table is properly removed from the database.
4. Run `php artisan migrate` again, and verify that it completes without errors.
