### PR TITLE
dynamic signing secret config

### DIFF
--- a/src/WebhookConfig.php
+++ b/src/WebhookConfig.php
@@ -33,7 +33,7 @@ class WebhookConfig
     {
         $this->name = $properties['name'];
 
-        $this->signingSecret = $properties['signing_secret'] ?? '';
+        $this->signingSecret = is_callable($properties['signing_secret']) ? $properties['signing_secret']() : ($properties['signing_secret'] ?? '');
 
         $this->signatureHeaderName = $properties['signature_header_name'] ?? '';
 


### PR DESCRIPTION
i think it should be better if can set the signing key dynamically....

for example if i want to take signing secret key from database, i can do like this

```
return [
  'configs' => [
      [
          ....
          'signing_secret' => function(){
              return \App\Models\Variable::where('key', 'thirdpartyapp.signing_secret_key')->first()->value ?? null;
          },
      ]
  ]
];
```

hope can merge this pr.. or if have another better way, please make it happen.. thank you very much....
by the way, very appreciate for creating this nice package....🙏