### PR TITLE
multiple config array indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,11 @@ This is the contents of the file that will be published at `config/webhook-clien
 
 return [
     'configs' => [
-        'default' => [
-            /*
-             * This package supports multiple webhook receiving endpoints. If you only have
-             * one endpoint receiving webhooks, you can use 'default'.
-             */
-            'name' => 'default',
-
+        /*
+         * This package supports multiple webhook receiving endpoints. If you only have
+         * one endpoint receiving webhooks, you can use 0 or 'default'.
+         */
+        0 => [
             /*
              * We expect that every webhook call will be signed using a secret. This secret
              * is used to verify that the payload has not been tampered with.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This is the contents of the file that will be published at `config/webhook-clien
 
 return [
     'configs' => [
-        [
+        'default' => [
             /*
              * This package supports multiple webhook receiving endpoints. If you only have
              * one endpoint receiving webhooks, you can use 'default'.
@@ -350,7 +350,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('model:prune', [
             '--model' => [WebhookCall::class],
         ])->daily();
-    
+
         // This will not work, as models in a package are not used by default
         // $schedule->command('model:prune')->daily();
     }

--- a/config/webhook-client.php
+++ b/config/webhook-client.php
@@ -2,13 +2,11 @@
 
 return [
     'configs' => [
-        [
-            /*
-             * This package supports multiple webhook receiving endpoints. If you only have
-             * one endpoint receiving webhooks, you can use 'default'.
-             */
-            'name' => 'default',
-
+        /*
+         * This package supports multiple webhook receiving endpoints. If you only have
+         * one endpoint receiving webhooks, you can use 'default' as the key.
+         */
+        'default' => [
             /*
              * We expect that every webhook call will be signed using a secret. This secret
              * is used to verify that the payload has not been tampered with.

--- a/config/webhook-client.php
+++ b/config/webhook-client.php
@@ -4,9 +4,9 @@ return [
     'configs' => [
         /*
          * This package supports multiple webhook receiving endpoints. If you only have
-         * one endpoint receiving webhooks, you can use 'default' as the key.
+         * one endpoint receiving webhooks, you can use either 0 or 'default' as the key.
          */
-        'default' => [
+        0 => [
             /*
              * We expect that every webhook call will be signed using a secret. This secret
              * is used to verify that the payload has not been tampered with.

--- a/src/WebhookClientServiceProvider.php
+++ b/src/WebhookClientServiceProvider.php
@@ -28,7 +28,7 @@ class WebhookClientServiceProvider extends PackageServiceProvider
             $configRepository = new WebhookConfigRepository();
 
             collect(config('webhook-client.configs'))
-                ->map(fn (array $config) => new WebhookConfig($config))
+                ->map(fn (array $config, string|int $index) => new WebhookConfig($config, $index))
                 ->each(fn (WebhookConfig $webhookConfig) => $configRepository->addConfig($webhookConfig));
 
             return $configRepository;

--- a/src/WebhookConfig.php
+++ b/src/WebhookConfig.php
@@ -31,7 +31,9 @@ class WebhookConfig
 
     public function __construct(array $properties, string|int|null $index = null)
     {
-        $this->name = $properties['name'] ?? $index ?? 'default';
+        $this->name = $properties['name']
+            ?? (0 === $index ? 'default' : $index)
+            ?? 'default';
 
         $this->signingSecret = $properties['signing_secret'] ?? '';
 

--- a/src/WebhookConfig.php
+++ b/src/WebhookConfig.php
@@ -29,9 +29,9 @@ class WebhookConfig
 
     public string $processWebhookJobClass;
 
-    public function __construct(array $properties)
+    public function __construct(array $properties, string|int|null $index = null)
     {
-        $this->name = $properties['name'];
+        $this->name = $properties['name'] ?? $index ?? 'default';
 
         $this->signingSecret = $properties['signing_secret'] ?? '';
 

--- a/tests/WebhookConfigTest.php
+++ b/tests/WebhookConfigTest.php
@@ -74,6 +74,7 @@ class WebhookConfigTest extends TestCase
     public function it_uses_the_config_array_index_if_provided()
     {
         $config = $this->getValidConfig();
+        unset($config['name']);
 
         $this->assertEquals('custom', (new WebhookConfig($config, 'custom'))->name);
     }

--- a/tests/WebhookConfigTest.php
+++ b/tests/WebhookConfigTest.php
@@ -71,6 +71,14 @@ class WebhookConfigTest extends TestCase
     }
 
     /** @test */
+    public function it_uses_the_config_array_index_if_provided()
+    {
+        $config = $this->getValidConfig();
+
+        $this->assertEquals('custom', (new WebhookConfig($config, 'custom'))->name);
+    }
+
+    /** @test */
     public function it_validates_the_process_webhook_job()
     {
         $config = $this->getValidConfig();


### PR DESCRIPTION
This assists apps using multiple webhook configs by allowing arbitrary index keys to be used

Specific use case: when testing one of multiple endpoints in my app, I need to set a config value:

```php
/**
 * Before
 */

// Find the key:
$key = collect(config('webhook-client.configs'))->where('name', 'new-issues')->keys()->first();
config(['webhook-client.configs.'.$key.'.signing_secret' => 'secret']);

// Or loop through them all:
collect(config('webhook-client.configs'))
  ->each(function (array $config, int $index) {
    if ($config['name'] === 'new-issues') {
      config(['webhook-client.configs.'.$index.'.signing_secret' => 'secret']);
    }
  });

// Or this, which breaks if the config file is reordered:
config(['webhook-client.configs.2.signing_secret' => 'secret']);

/**
 * After
 */
config(['webhook-client.configs.new-issues.signing_secret' => 'secret']);
```

Another specific use case: in some of my endpoints, I use other config values in the webhook profile class and want to retrieve those from the config:

```php
/**
 * Before
 */
$formIds = collect(config('webhook-client.configs'))->firstWhere('name', 'new-issues')['form-ids'];

/**
 * After
 */
$formIds = config('webhook-client.configs.new-issues.form-ids');
```

---

I realize that I can add my own array indices in my app and that does work fine. I figured this may be useful to a wider audience as well, and added the ability to use the index key as the name.

This should be backwards-compatible for existing installations.