### PR TITLE
perf: save exception as null by default :rocket: 

### DIFF
--- a/src/Models/WebhookCall.php
+++ b/src/Models/WebhookCall.php
@@ -55,6 +55,7 @@ class WebhookCall extends Model
             'url' => $request->fullUrl(),
             'headers' => $headers,
             'payload' => $request->input(),
+            'exception' => null,
         ]);
     }
 


### PR DESCRIPTION
Hi @freekmurze 

While profiling our Laravel app via Sentry, we found that this package is making one extra SQL query on each incoming webhook request.

This package saves the model and then dispatch the respective job, but it also [clears](https://github.com/spatie/laravel-webhook-client/blob/39db686528d46523a2535b72888f360a417ef520/src/WebhookProcessor.php#L56) any saved exception before as well.

![Web capture_2-5-2023_18204](https://user-images.githubusercontent.com/6111524/235671379-0a4de811-a34a-4c8f-ade1-3f1f84ccd386.jpeg)

Saving the `exception` as `null` will let Laravel know that the model is not dirty and Laravel will skip updating the row automatically.

This will save around 10k SQL queries daily on our server.  :smile: 

Thanks again for this wonderful package.
