### PR TITLE
Enhance Webhook Client to Support Multiple HTTP Methods for Receiving Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Finally, let's take care of the routing. At the app that sends webhooks, you pro
 Route::webhooks('webhook-receiving-url');
 ```
 
-Behind the scenes, this will register a `POST` (But you can change method. Check Usage section👇) route to a controller provided by this package. Because the app that sends webhooks to you has no way of getting a csrf-token, you must add that route to the `except` array of the `VerifyCsrfToken` middleware:
+Behind the scenes, by default this will register a `POST` route to a controller provided by this package. Because the app that sends webhooks to you has no way of getting a csrf-token, you must add that route to the `except` array of the `VerifyCsrfToken` middleware:
 
 ```php
 protected $except = [

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Finally, let's take care of the routing. At the app that sends webhooks, you pro
 Route::webhooks('webhook-receiving-url');
 ```
 
-Behind the scenes, this will register a `POST` route to a controller provided by this package. Because the app that sends webhooks to you has no way of getting a csrf-token, you must add that route to the `except` array of the `VerifyCsrfToken` middleware:
+Behind the scenes, this will register a `POST` (But you can change method. Check Usage section👇) route to a controller provided by this package. Because the app that sends webhooks to you has no way of getting a csrf-token, you must add that route to the `except` array of the `VerifyCsrfToken` middleware:
 
 ```php
 protected $except = [
@@ -290,6 +290,15 @@ When registering routes for the package, you should pass the `name` of the confi
 ```php
 Route::webhooks('receiving-url-for-app-1', 'webhook-sending-app-1');
 Route::webhooks('receiving-url-for-app-2', 'webhook-sending-app-2');
+```
+
+### Change route method
+Being an incoming webhook client, there are instances where you might want to establish a route method other than the default `post`. You have the flexibility to modify the standard post method to options such as `get`, `put`, `patch`, or `delete`.
+```php
+Route::webhooks('receiving-url-for-app-1', 'webhook-sending-app-1', 'get');
+Route::webhooks('receiving-url-for-app-1', 'webhook-sending-app-1', 'put');
+Route::webhooks('receiving-url-for-app-1', 'webhook-sending-app-1', 'patch');
+Route::webhooks('receiving-url-for-app-1', 'webhook-sending-app-1', 'delete');
 ```
 
 ### Using the package without a controller

--- a/src/Exceptions/InvalidMethod.php
+++ b/src/Exceptions/InvalidMethod.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\WebhookClient\Exceptions;
+
+use Exception;
+
+class InvalidMethod extends Exception
+{
+    public static function make($method): self
+    {
+        return new static("The method $method is not allowed.");
+    }
+}

--- a/src/WebhookClientServiceProvider.php
+++ b/src/WebhookClientServiceProvider.php
@@ -19,22 +19,15 @@ class WebhookClientServiceProvider extends PackageServiceProvider
             ->hasMigrations('create_webhook_calls_table');
     }
 
-    /**
-     * @throws \Spatie\WebhookClient\Exceptions\InvalidMethod
-     */
-    private function validatedMethod(string $method): string
-    {
-        if(! in_array($method, ['get', 'post', 'put', 'patch', 'delete'])) {
-            throw InvalidMethod::make($method);
-        }
-
-        return $method;
-    }
-
     public function packageBooted()
     {
         Route::macro('webhooks', function (string $url, string $name = 'default', $method = 'post') {
-            return Route::{$this->validatedMethod($method)}($url, '\Spatie\WebhookClient\Http\Controllers\WebhookController')->name("webhook-client-{$name}");
+
+            if(! in_array($method, ['get', 'post', 'put', 'patch', 'delete'])) {
+                throw InvalidMethod::make($method);
+            }
+
+            return Route::{$method}($url, '\Spatie\WebhookClient\Http\Controllers\WebhookController')->name("webhook-client-{$name}");
         });
 
         $this->app->scoped(WebhookConfigRepository::class, function () {

--- a/src/WebhookClientServiceProvider.php
+++ b/src/WebhookClientServiceProvider.php
@@ -20,8 +20,8 @@ class WebhookClientServiceProvider extends PackageServiceProvider
 
     public function packageBooted()
     {
-        Route::macro('webhooks', function (string $url, string $name = 'default') {
-            return Route::post($url, '\Spatie\WebhookClient\Http\Controllers\WebhookController')->name("webhook-client-{$name}");
+        Route::macro('webhooks', function (string $url, string $name = 'default', $method = 'post') {
+            return Route::{$method}($url, '\Spatie\WebhookClient\Http\Controllers\WebhookController')->name("webhook-client-{$name}");
         });
 
         $this->app->scoped(WebhookConfigRepository::class, function () {

--- a/src/WebhookClientServiceProvider.php
+++ b/src/WebhookClientServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Str;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Spatie\WebhookClient\Exceptions\InvalidConfig;
+use Spatie\WebhookClient\Exceptions\InvalidMethod;
 
 class WebhookClientServiceProvider extends PackageServiceProvider
 {
@@ -18,10 +19,22 @@ class WebhookClientServiceProvider extends PackageServiceProvider
             ->hasMigrations('create_webhook_calls_table');
     }
 
+    /**
+     * @throws \Spatie\WebhookClient\Exceptions\InvalidMethod
+     */
+    private function validatedMethod(string $method): string
+    {
+        if(! in_array($method, ['get', 'post', 'put', 'patch', 'delete'])) {
+            throw InvalidMethod::make($method);
+        }
+
+        return $method;
+    }
+
     public function packageBooted()
     {
         Route::macro('webhooks', function (string $url, string $name = 'default', $method = 'post') {
-            return Route::{$method}($url, '\Spatie\WebhookClient\Http\Controllers\WebhookController')->name("webhook-client-{$name}");
+            return Route::{$this->validatedMethod($method)}($url, '\Spatie\WebhookClient\Http\Controllers\WebhookController')->name("webhook-client-{$name}");
         });
 
         $this->app->scoped(WebhookConfigRepository::class, function () {


### PR DESCRIPTION
Currently, the package only supports the 'POST' method for receiving webhook requests. However, it would be beneficial to extend this functionality to handle requests with any method, such as 'GET', 'PUT', and more.

One specific use case we encountered was when working with ElasticMail. They send webhook requests using the 'GET' method, which is not currently supported by the package. To ensure compatibility with ElasticMail and other services that utilize different HTTP methods, we need to enhance the webhook client to handle these requests appropriately.