### PR TITLE
Drop laravel 8 and php 8.0, add support php 8.3 on github action workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.2, 8.1, 8.0]
-        laravel: [10.*, 9.*, 8.*]
+        php: [8.3, 8.2, 8.1]
+        laravel: [10.*, 9.*,]
         dependency-version: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         include:
@@ -23,12 +23,6 @@ jobs:
           - laravel: 9.*
             testbench: ^7.0
             carbon: ^2.63
-          - laravel: 8.*
-            testbench: ^6.23
-            carbon: ^2.63
-        exclude:
-          - laravel: 10.*
-            php: 8.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,15 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "illuminate/bus": "^8.50|^9.0|^10.0",
-        "illuminate/database": "^8.50|^9.0|^10.0",
-        "illuminate/support": "^8.50|^9.0|^10.0",
+        "php": "^8.1",
+        "illuminate/bus": "^9.0|^10.0",
+        "illuminate/database": "^9.0|^10.0",
+        "illuminate/support": "^9.0|^10.0",
         "spatie/laravel-package-tools": "^1.11"
     },
     "require-dev": {
         "nunomaduro/larastan": "^1.0.4|^2.2",
-        "orchestra/testbench": "^6.0|^7.0|^8.0",
+        "orchestra/testbench": "^7.0|^8.0",
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",


### PR DESCRIPTION
PHP8.0 is now unsupported https://php.watch/versions
Laravel 8.0 now is unsupported https://laravelversions.com/en