### PR TITLE
Update README.md to Laravel 11 Schedule for Prune

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,27 +343,19 @@ return [
 ```
 
 After configuring the model, you should schedule the `model:prune` Artisan command in your
-application's `Kernel` class. Don't forget to explicitly mention the `WebhookCall` class.
+application's `route/console.php`. Don't forget to explicitly mention the `WebhookCall` class.
 You are free to choose the appropriate interval at which this command should be run:
 
 ```php
-namespace App\Console;
-
-use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+use Illuminate\Support\Facades\Schedule;
 use Spatie\WebhookClient\Models\WebhookCall;
 
-class Kernel extends ConsoleKernel
-{
-    protected function schedule(Schedule $schedule)
-    {
-        $schedule->command('model:prune', [
-            '--model' => [WebhookCall::class],
-        ])->daily();
-    
-        // This will not work, as models in a package are not used by default
-        // $schedule->command('model:prune')->daily();
-    }
-}
+Schedule::command('model:prune', [
+    '--model' => [WebhookCall::class],
+])->daily();
+
+// This will not work, as models in a package are not used by default
+// Schedule::command('model:prune')->daily();
 ```
 
 ## Testing


### PR DESCRIPTION
Laravel 11 has no Kernel file in the app anymore, the Schedule for the Prunable should be set in the routes/console.php