### PR TITLE
Extend InvalidWebhookSignatureEvent with WebhookConfig parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ protected $except = [
 
 ## Usage
 
-With the installation out of the way, let's take a look at how this package handles webhooks. First, it will verify if the signature of the request is valid. If it is not, we'll throw an exception and fire off the `InvalidSignatureEvent` event. Requests with invalid signatures will not be stored in the database.
+With the installation out of the way, let's take a look at how this package handles webhooks. First, it will verify if the signature of the request is valid. If it is not, we'll throw an exception and fire off the `InvalidWebhookSignatureEvent` event. Requests with invalid signatures will not be stored in the database.
 
 Next, the request will be passed to a webhook profile. A webhook profile is a class that determines if a request should be stored and processed by your app. It allows you to filter out webhook requests that are of interest to your app. You can easily create [your own webhook profile](#determining-which-webhook-requests-should-be-stored-and-processed).
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -50,3 +50,5 @@ class AddColumnsToWebhookCalls extends Migration
 - the `Spatie\WebhookClient\Events\InvalidSignature` event has been renamed to `Spatie\WebhookClient\Events\InvalidWebhookSignatureEvent`
 
 - the `Spatie\WebhookClient\ProcessWebhookJob` job has been moved to `Spatie\WebhookClient\Jobs\ProcessWebhookJob`
+
+- the `Spatie\WebhookClient\Events\InvalidWebhookSignatureEvent` event get the `Spatie\WebhookClient\WebhookConfig` as parameter

--- a/src/Events/InvalidWebhookSignatureEvent.php
+++ b/src/Events/InvalidWebhookSignatureEvent.php
@@ -3,11 +3,13 @@
 namespace Spatie\WebhookClient\Events;
 
 use Illuminate\Http\Request;
+use Spatie\WebhookClient\WebhookConfig;
 
 class InvalidWebhookSignatureEvent
 {
     public function __construct(
-        public Request $request
+        public Request $request,
+        public WebhookConfig $config
     ) {
     }
 }

--- a/src/WebhookProcessor.php
+++ b/src/WebhookProcessor.php
@@ -35,7 +35,7 @@ class WebhookProcessor
     protected function ensureValidSignature(): self
     {
         if (! $this->config->signatureValidator->isValid($this->request, $this->config)) {
-            event(new InvalidWebhookSignatureEvent($this->request));
+            event(new InvalidWebhookSignatureEvent($this->request, $this->config));
 
             throw InvalidWebhookSignature::make();
         }


### PR DESCRIPTION
If the application connects several webhook clients, it is now easy to find out which webhook it is. This allows errors to be dealt with individually.

In our specific example, the external webhook service cannot correctly calculate the signature with a UTF8 payload, so that we can call the GET API of the external service in the event of an error.

e.g.

```php 
    public function handle(InvalidWebhookSignatureEvent $event): void
    {
        if ($event->config->processWebhookJobClass !== CustomWebhookJob::class) {
            return;
        }

        // do something specific 
    }
```