### PR TITLE
Change hash_equals order parameters

### DIFF
--- a/src/SignatureValidator/DefaultSignatureValidator.php
+++ b/src/SignatureValidator/DefaultSignatureValidator.php
@@ -24,6 +24,6 @@ class DefaultSignatureValidator implements SignatureValidator
 
         $computedSignature = hash_hmac('sha256', $request->getContent(), $signingSecret);
 
-        return hash_equals($signature, $computedSignature);
+        return hash_equals($computedSignature, $signature);
     }
 }


### PR DESCRIPTION
In [hash_equals ](https://www.php.net/manual/en/function.hash-equals.php) documentation, there is a caution 

> It is important to provide the user-supplied string as the second parameter, rather than the first.

So, I inverted parameters in DefaultSignatureValidator


