### PR TITLE
Truncate url to fit in 255 varchar field

### DIFF
--- a/src/Models/WebhookCall.php
+++ b/src/Models/WebhookCall.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Request;
 use Spatie\WebhookClient\Exceptions\InvalidConfig;
 use Spatie\WebhookClient\WebhookConfig;
 use Symfony\Component\HttpFoundation\HeaderBag;
+use Illuminate\Support\Str;
 
 /**
  * Class WebhookCall
@@ -52,7 +53,7 @@ class WebhookCall extends Model
 
         return self::create([
             'name' => $config->name,
-            'url' => $request->fullUrl(),
+            'url' => Str::limit($request->fullUrl(), 252),
             'headers' => $headers,
             'payload' => $request->input(),
             'exception' => null,

--- a/tests/Unit/WebhookCallTest.php
+++ b/tests/Unit/WebhookCallTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Spatie\WebhookClient\Tests\Unit;
+
+use Illuminate\Http\Request;
+use Spatie\WebhookClient\Models\WebhookCall;
+use Spatie\WebhookClient\SignatureValidator\DefaultSignatureValidator;
+use Spatie\WebhookClient\Tests\TestCase;
+use Spatie\WebhookClient\Tests\TestClasses\ProcessWebhookJobTestClass;
+use Spatie\WebhookClient\WebhookConfig;
+use Spatie\WebhookClient\WebhookProfile\ProcessEverythingWebhookProfile;
+
+class WebhookCallTest extends TestCase
+{
+    /** @test */
+    public function it_stores_url_without_truncation_when_under_255_characters()
+    {
+        $url = 'https://example.com/webhook?param=value';
+        $request = Request::create($url);
+        $config = new WebhookConfig([
+            'name' => 'test',
+            'signing_secret' => 'test',
+            'signature_header_name' => 'test',
+            'signature_validator' => DefaultSignatureValidator::class,
+            'webhook_profile' => ProcessEverythingWebhookProfile::class,
+            'webhook_response' => null,
+            'webhook_model' => WebhookCall::class,
+            'store_headers' => [],
+            'process_webhook_job' => ProcessWebhookJobTestClass::class
+        ]);
+
+        $webhookCall = WebhookCall::storeWebhook($config, $request);
+
+        $this->assertEquals($url, $webhookCall->url);
+    }
+
+    /** @test */
+    public function it_truncates_url_when_exceeding_255_characters()
+    {
+        $baseUrl = 'https://example.com/webhook?';
+        $params = [];
+        for ($i = 0; $i < 100; $i++) {
+            $params[] = "param{$i}=" . str_repeat('x', 10);
+        }
+        $longUrl = $baseUrl . implode('&', $params);
+        $request = Request::create($longUrl);
+        $config = new WebhookConfig([
+            'name' => 'test',
+            'signing_secret' => 'test',
+            'signature_header_name' => 'test',
+            'signature_validator' => DefaultSignatureValidator::class,
+            'webhook_profile' => ProcessEverythingWebhookProfile::class,
+            'webhook_response' => null,
+            'webhook_model' => WebhookCall::class,
+            'store_headers' => [],
+            'process_webhook_job' => ProcessWebhookJobTestClass::class
+        ]);
+
+        $webhookCall = WebhookCall::storeWebhook($config, $request);
+
+        $this->assertLessThanOrEqual(255, strlen($webhookCall->url));
+        $this->assertStringEndsWith('...', $webhookCall->url);
+    }
+} 


### PR DESCRIPTION
Fix an issue where webhooks from a URL longer than a 255 varchar field are not stored in webhook_calls table

Had this issue when I was expecting a verification token from AWS IoT where the token was included in the URL as well as the body of the webhook

Uses the limit function of the already required illuminate support library to truncate the incoming URL to 252 characters, which will  fit in varchar 255 along with the ellipsis that illuminate appends to signify it's been truncated