### PR TITLE
fix SQLSTATE[42703] column "attachments" does not exist

### DIFF
--- a/src/Models/WebhookCall.php
+++ b/src/Models/WebhookCall.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\MassPrunable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Schema;
 use Spatie\WebhookClient\Exceptions\InvalidConfig;
 use Spatie\WebhookClient\WebhookConfig;
 use Symfony\Component\HttpFoundation\HeaderBag;
@@ -50,14 +51,19 @@ class WebhookCall extends Model
 
     public static function storeWebhook(WebhookConfig $config, Request $request): WebhookCall
     {
-        return self::create([
+        $data = [
             'name' => $config->name,
             'url' => $request->fullUrl(),
             'headers' => self::headersToStore($config, $request),
             'payload' => self::buildPayloadFromRequest($request),
-            'attachments' => self::buildAttachmentsFromRequest($config, $request),
             'exception' => null,
-        ]);
+        ];
+
+        if (Schema::hasColumn((new self)->getTable(), 'attachments')) {
+            $data['attachments'] = self::buildAttachmentsFromRequest($config, $request);
+        }
+
+        return self::create($data);
     }
 
     protected static function buildPayloadFromRequest(Request $request): array

--- a/tests/WebhookCallModelTest.php
+++ b/tests/WebhookCallModelTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
 use Spatie\WebhookClient\Models\WebhookCall;
 use Spatie\WebhookClient\WebhookConfig;
@@ -318,4 +320,16 @@ test('process request files method handles array of files correctly', function (
     expect($result)->toHaveCount(2);
     expect($result[0]['originalName'])->toBe('test1.txt');
     expect($result[1]['originalName'])->toBe('test2.txt');
+});
+
+it('stores a webhook call when the attachments column does not exist', function () {
+    Schema::table('webhook_calls', function (Blueprint $table) {
+        $table->dropColumn('attachments');
+    });
+
+    $request = Request::create('/test', 'POST', ['key' => 'value']);
+    $webhookCall = WebhookCall::storeWebhook($this->webhookConfig, $request);
+
+    expect($webhookCall->exists)->toBeTrue();
+    expect($webhookCall->name)->toBe('test');
 });


### PR DESCRIPTION
fixes #250  

v 3.6.0 had a silent breaking change.
Backwards compatibility was ensured on the read side but not when writing to db.

This checks if db column exists before insert.