### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ return Application::configure(basePath: dirname(__DIR__))
        // ...
     )
     ->withMiddleware(function (Middleware $middleware) {
-        $middleware->validateCsrfTokens(except: [
+        $middleware->preventRequestForgery(except: [
             'your-webhook-receiving-url'
         ]);
     })->create();


### PR DESCRIPTION
The validateCsrfTokens function has been deprecated. Consider using preventRequestForgery.